### PR TITLE
DT Ars Addon Compat

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -53,4 +53,18 @@ description='''${mod_description}'''
     ordering="AFTER"
     side="BOTH"
 
+[[dependencies."${mod_id}"]]
+    modId="dtnatures_spirit"
+    type="optional"
+    versionRange="[1.3,)"
+    ordering="AFTER"
+    side="BOTH"
+
+[[dependencies."${mod_id}"]]
+    modId="dtterralith"
+    type="optional"
+    versionRange="[1.3.0-BETA01,)"
+    ordering="AFTER"
+    side="BOTH"
+
 #openGLVersion="[3.2,)"


### PR DESCRIPTION
Makes DT ars trees spawn in forest biomes of DT terralith and DT nature's spirit